### PR TITLE
FStar 2024.01.13 y Ubuntu 22.04

### DIFF
--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 
@@ -57,7 +57,7 @@ RUN wget -nv https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-
 #  && ln -s $(realpath bin/fstar.exe) $HOME/bin/fstar.exe
 
 # Get F* release and extract into home
-ARG FSTAR_RELEASE_LINK=https://github.com/FStarLang/FStar/releases/download/v2023.04.25/fstar_2023.04.25_Linux_x86_64.tar.gz
+ARG FSTAR_RELEASE_LINK=https://github.com/FStarLang/FStar/releases/download/v2024.01.13/fstar_2024.01.13_Linux_x86_64.tar.gz
 RUN wget -nv $FSTAR_RELEASE_LINK \
  && tar xzf fstar_*.tar.gz -C $HOME \
  && ln -s $(realpath fstar/bin/fstar.exe) $HOME/bin/fstar.exe


### PR DESCRIPTION
Actualiza F* a la ultima versión por problemas con `|>` en `Clase8.WP.fst`.
Modifica Ubuntu a 22.04 por conflictos de la ultima versión con una libreria